### PR TITLE
jq: changed mod_path to support linux and MacOS

### DIFF
--- a/smdGOG.py
+++ b/smdGOG.py
@@ -69,7 +69,7 @@ def modify_dot_mod():
 
     # NOTE(jq): Not sure if needed, test if '/' works on Windows
     if _platform == "win32" or _platform == "win64":
-        f = open(usr_mod_path + "//" + dot_mod, "r+")
+        f = open(usr_mod_path + "\\" + dot_mod, "r+")
     else:
         # MacOS or Linux NOTE(jq): not test on MacOS
         f = open(usr_mod_path + "/" + dot_mod, "r+")

--- a/smdGOG.py
+++ b/smdGOG.py
@@ -12,10 +12,14 @@ if _platform == "linux" or _platform == "linux2":
     mod_path = "/.local/share/Paradox Interactive/Stellaris/mod"
 elif _platform == "darwin":
     # MAC OS X
-    pass
+    mod_path = "/Documents/Paradox Interactive/Stellaris/mod"
 elif _platform == "win32" or _platform == "win64":
     # Windows
     mod_path = "\\Documents\\Paradox Interactive\\Stellaris\\mod"
+else:
+    # NOTE(jq):assume Linux?
+    mod_path = "/.local/share/Paradox Interactive/Stellaris/mod"
+
 
 # expected full user mod path on Windows 10
 usr_mod_path = path.expanduser("~") + mod_path
@@ -64,10 +68,11 @@ def modify_dot_mod():
     global dot_mod
     dot_mod = zip_list[1]
 
-    # NOTE: Not sure if needed
+    # NOTE(jq): Not sure if needed, test if '/' works on Windows
     if _platform == "win32" or _platform == "win64":
         f = open(usr_mod_path + "//" + dot_mod, "r+")
     else:
+        # MacOS or Linux NOTE(jq): not test on MacOS
         f = open(usr_mod_path + "/" + dot_mod, "r+")
 
     try:

--- a/smdGOG.py
+++ b/smdGOG.py
@@ -1,12 +1,25 @@
 from os import path, chdir, makedirs
+#import platform
+from sys import platform as _platform
 from zipfile import ZipFile
 import sys
 from subprocess import Popen
 
 # Stellaris mod folder path for the GOG version of the game
-mod_path = "\\Documents\\Paradox Interactive\\Stellaris\\mod"
+
+if _platform == "linux" or _platform == "linux2":
+    # linux
+    mod_path = "/.local/share/Paradox Interactive/Stellaris/mod"
+elif _platform == "darwin":
+    # MAC OS X
+    pass
+elif _platform == "win32" or _platform == "win64":
+    # Windows
+    mod_path = "\\Documents\\Paradox Interactive\\Stellaris\\mod"
+
 # expected full user mod path on Windows 10
 usr_mod_path = path.expanduser("~") + mod_path
+
 # onto the pyscript drag and dropped zip file
 
 # test.zip path, this is obsolute
@@ -22,7 +35,7 @@ def find_mod_folder():
         try:
             makedirs(usr_mod_path)
         except OSError:
-                print("failed creating mod folder!")
+            print("failed creating mod folder!")
 
 
 def unzip_mod_zip():
@@ -35,10 +48,10 @@ def unzip_mod_zip():
 
         for item in zip_list:
             if item.endswith(".mod"):
-                    zipfile.extractall(usr_mod_path)
-                    found = True
-                    print("zip extracted to " + usr_mod_path)
-                    break
+                zipfile.extractall(usr_mod_path)
+                found = True
+                print("zip extracted to " + usr_mod_path)
+                break
 
     if not found:
         print("zip doesnt contain .mod file!")
@@ -50,7 +63,12 @@ def modify_dot_mod():
     # assign 2nd item from previous list to a var and modify the file
     global dot_mod
     dot_mod = zip_list[1]
-    f = open(usr_mod_path + "\\" + dot_mod, "r+")
+
+    # NOTE: Not sure if needed
+    if _platform == "win32" or _platform == "win64":
+        f = open(usr_mod_path + "//" + dot_mod, "r+")
+    else:
+        f = open(usr_mod_path + "/" + dot_mod, "r+")
 
     try:
         dm_c = f.read()

--- a/smdGOG.py
+++ b/smdGOG.py
@@ -1,5 +1,4 @@
 from os import path, chdir, makedirs
-#import platform
 from sys import platform as _platform
 from zipfile import ZipFile
 import sys


### PR DESCRIPTION
Changed mod path to support Linux or MacOS if OS is correctly detected.
On Linux mods are located: '\~/.local/share/Paradox Interactive/Stellaris/mod' ( At least on my machine. )
On MacOS mods are located: \'~/Documents/Paradox Interactive/Stellaris/mod' ( same as Windows, but without double slashes. )
Path taken from wiki: https://stellaris.paradoxwikis.com/Mods#Installation

Only tested on Arch Linux.